### PR TITLE
Fix using more than one parameter in a command line

### DIFF
--- a/Core/Inc/command_handler.h
+++ b/Core/Inc/command_handler.h
@@ -14,6 +14,13 @@ template <typename T> void fetch_param(const char *pstr, size_t len, T &param)
 
 template <> void fetch_param(const char *pstr, size_t len, FWT::str &str);
 template <> void fetch_param(const char *pstr, size_t len, int &num);
+template <typename Tail>
+    void FillParamTuple(const char *params, size_t length, FWT::tuple<Tail> &tup)
+{
+    Tail val;
+    fetch_param(params, length, val);
+    tup.set(val);
+}
 
 template <typename Head, typename ...Tail>
     void FillParamTuple(const char *params, size_t length, FWT::tuple<Head, Tail...> &tup)
@@ -27,18 +34,11 @@ template <typename Head, typename ...Tail>
             Head val;
             fetch_param(param_start, ptr - param_start, val);
             tup.set(val);
-            FillParamTuple<Tail...>(ptr + 1, length - (ptr - params), tup.get_rest());
+            ptr++;
+            FillParamTuple<Tail...>(ptr, length - (ptr - params), tup.get_rest());
             return;
         }
     }
-}
-
-template <typename Tail>
-    void FillParamTuple(const char *params, size_t length, FWT::tuple<Tail> &tup)
-{
-    Tail val;
-    fetch_param(params, length, val);
-    tup.set(val);
 }
 
 template <>
@@ -63,7 +63,7 @@ public:
 
         FWT::tuple<Args...> params; 
         FillParamTuple<Args...>(param_start, length - (param_start - command), params);
-        
+
         _handler(params);
 
         return true; 

--- a/Core/Inc/templates.h
+++ b/Core/Inc/templates.h
@@ -37,10 +37,15 @@ public:
         return _data;
     }
 
-    const tuple <Tail ...> &get_rest() const 
+    const tuple<Tail...> &get_rest() const
+    {
+        return _rest;
+    }
+
+    tuple <Tail ...> &get_rest()
     {
         return _rest; 
-    } 
+    }
 
 private:
     Head _data;


### PR DESCRIPTION
In current version I could use MakeCommandHandler() with just one parameter.
If I tried to create something like:
```
void NandPrintPageDataHandlerFn(const FWT::tuple<uint16_t, uint16_t, size_t, size_t> &params)
{
  // ...
}
auto nandPrintPageDataHandler =
  MakeCommandHandler<typeof(NandPrintPageDataHandlerFn), uint16_t, uint16_t, size_t, size_t>
    ("read", NandPrintPageDataHandlerFn);
```
compiler gave an error.